### PR TITLE
adds .today (because we all love holidays)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ is technically a plugin for (though he himself has a multitude of plugins as wel
 
 [Danny Hinshaw](https://github.com/DannyHinshaw)
 
+[Benjamin Matthews](https://github.com/bmatt468)
+
 ## License
 
 The MIT License (see [LICENSE](LICENSE))

--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,7 @@ Contributors
 ------------
 
 `Danny Hinshaw <https://github.com/DannyHinshaw>`__
+`Benjamin Matthews <https://github.com/bmatt468>`__
 
 License
 -------

--- a/botty_mcbotface/plugins/today.py
+++ b/botty_mcbotface/plugins/today.py
@@ -1,0 +1,21 @@
+from slackbot.bot import listen_to, re
+from datetime import date
+import feedparser
+
+
+@listen_to('^.today', re.IGNORECASE)
+def today(message):
+    """
+    Returns all the holidays for today
+    :param message: Slackbot message object
+    :return: Message to slack channel
+    """
+    today = date.today().strftime("%A, %B %d, %Y.")
+    msg = "Today is {}\nToday's Holidays:\n".format(today)
+
+    holidays = feedparser.parse("https://www.checkiday.com/rss.php?tz=America/New_York")
+
+    for holiday in holidays.entries:
+        msg += holiday.title + "\n"
+
+    return message.send(msg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 beautifulsoup4==4.6.0
+bs4==0.0.1
 certifi==2017.7.27.1
 chardet==3.0.4
+feedparser==5.2.1
 idna==2.6
 lxml==3.8.0
 requests==2.18.4


### PR DESCRIPTION
This pull adds the `.today` command. This command will display the date, and then a list of holidays that are associated with the day (because we all love holidays).

Example output:
```
Today is Friday, September 15, 2017.
Today's Holidays:
Google.com Day
Greenpeace Day
International Day of Democracy
International Dot Day
Make a Hat Day
National Caregivers Day
National Cheese Toast Day
National Crème de Menthe Day
National Double Cheeseburger Day
National Felt Hat Day
```

Hopefully I followed the proper standard for python. Still getting back into the swing of it 😬